### PR TITLE
Add timeout argument for async

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,5 @@
+### v0.1.1
+  * added timeout parameter
+
 ### v0.1.0
   * Initial Release

--- a/lib/jasmine.async.js
+++ b/lib/jasmine.async.js
@@ -1,5 +1,5 @@
 // Jasmine.Async, v0.1.0
-// Copyright (c)2012 Muted Solutions, LLC. All Rights Reserved.
+// Copyright (c)2013 Muted Solutions, LLC. All Rights Reserved.
 // Distributed under MIT license
 // http://github.com/derickbailey/jasmine.async
 this.AsyncSpec = (function(global){

--- a/lib/jasmine.async.js
+++ b/lib/jasmine.async.js
@@ -7,7 +7,7 @@ this.AsyncSpec = (function(global){
   // Private Methods
   // ---------------
   
-  function runAsync(block){
+  function runAsync(block, timeout){
     return function(){
       var done = false;
       var complete = function(){ done = true; };
@@ -18,7 +18,7 @@ this.AsyncSpec = (function(global){
 
       waitsFor(function(){
         return done;
-      });
+      }, null, timeout);
     };
   }
 
@@ -40,11 +40,11 @@ this.AsyncSpec = (function(global){
     this.spec.afterEach(runAsync(block));
   };
 
-  AsyncSpec.prototype.it = function(description, block){
+  AsyncSpec.prototype.it = function(description, block, timeout){
     // For some reason, `it` is not attached to the current
     // test suite, so it has to be called from the global
     // context.
-    global.it(description, runAsync(block));
+    global.it(description, runAsync(block, timeout));
   };
 
   return AsyncSpec;

--- a/lib/jasmine.async.min.js
+++ b/lib/jasmine.async.min.js
@@ -1,5 +1,5 @@
 // Jasmine.Async, v0.1.0
-// Copyright (c)2012 Muted Solutions, LLC. All Rights Reserved.
+// Copyright (c)2013 Muted Solutions, LLC. All Rights Reserved.
 // Distributed under MIT license
 // http://github.com/derickbailey/jasmine.async
-this.AsyncSpec=function(a){function b(a){return function(){var b=!1,c=function(){b=!0};runs(function(){a(c)}),waitsFor(function(){return b})}}function c(a){this.spec=a}return c.prototype.beforeEach=function(a){this.spec.beforeEach(b(a))},c.prototype.afterEach=function(a){this.spec.afterEach(b(a))},c.prototype.it=function(c,d){a.it(c,b(d))},c}(this);
+this.AsyncSpec=function(e){function t(e,t){return function(){var n=!1,r=function(){n=!0};runs(function(){e(r)}),waitsFor(function(){return n},null,t)}}function n(e){this.spec=e}return n.prototype.beforeEach=function(e){this.spec.beforeEach(t(e))},n.prototype.afterEach=function(e){this.spec.afterEach(t(e))},n.prototype.it=function(n,r,i){e.it(n,t(r,i))},n}(this);

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,22 @@ describe("an async spec", function(){
 
   });
 
+  // run an async with customized timeout
+  async.it("did stuff slowly", function(done){
+
+    // simulate async code again
+    setTimeout(function(){
+
+      expect(1).toBe(1);
+      
+      // all async stuff done, and spec asserted
+      done();
+
+    }, 10000 /* 10secs */);    
+
+  },11000 /* 11secs */);
+
+
 });
 ```
 

--- a/spec/javascripts/jasmine.async.spec.js
+++ b/spec/javascripts/jasmine.async.spec.js
@@ -22,6 +22,12 @@ describe("jasmine.async", function(){
     }, wait);    
   });
 
+  async.it("Allow customized timeout", function(done){
+    setTimeout(function(){
+      done();
+    }, 10000);    
+  },11000);
+
   async.afterEach(function(done){
     setTimeout(function(){
       done();

--- a/src/jasmine.async.js
+++ b/src/jasmine.async.js
@@ -3,7 +3,7 @@ this.AsyncSpec = (function(global){
   // Private Methods
   // ---------------
   
-  function runAsync(block){
+  function runAsync(block, timeout){
     return function(){
       var done = false;
       var complete = function(){ done = true; };
@@ -14,7 +14,7 @@ this.AsyncSpec = (function(global){
 
       waitsFor(function(){
         return done;
-      });
+      }, null, timeout);
     };
   }
 
@@ -36,11 +36,11 @@ this.AsyncSpec = (function(global){
     this.spec.afterEach(runAsync(block));
   };
 
-  AsyncSpec.prototype.it = function(description, block){
+  AsyncSpec.prototype.it = function(description, block, timeout){
     // For some reason, `it` is not attached to the current
     // test suite, so it has to be called from the global
     // context.
-    global.it(description, runAsync(block));
+    global.it(description, runAsync(block, timeout));
   };
 
   return AsyncSpec;


### PR DESCRIPTION
A simple change to allow timeout parameter to be passed to feature implemented in:

https://github.com/mhevery/jasmine-node/pull/142

Please do let me know if there's any feedback.

Thanks for this great snippet that make life easier for async test.
