### PR TITLE
Fix for thrown errors never invoking complete 

### DIFF
--- a/lib/jasmine.async.js
+++ b/lib/jasmine.async.js
@@ -1,5 +1,5 @@
 // Jasmine.Async, v0.1.0
-// Copyright (c)2012 Muted Solutions, LLC. All Rights Reserved.
+// Copyright (c)2013 Muted Solutions, LLC. All Rights Reserved.
 // Distributed under MIT license
 // http://github.com/derickbailey/jasmine.async
 this.AsyncSpec = (function(global){
@@ -13,7 +13,12 @@ this.AsyncSpec = (function(global){
       var complete = function(){ done = true; };
 
       runs(function(){
-        block(complete);
+        try{
+          block(complete);
+        } catch ( error ){
+          complete();
+          throw error;
+        }
       });
 
       waitsFor(function(){

--- a/lib/jasmine.async.js
+++ b/lib/jasmine.async.js
@@ -14,7 +14,7 @@ this.AsyncSpec = (function(global){
 
       runs(function(){
         try{
-          block(complete);
+          block.call(this,complete);
         } catch ( error ){
           complete();
           throw error;

--- a/lib/jasmine.async.min.js
+++ b/lib/jasmine.async.min.js
@@ -1,5 +1,5 @@
 // Jasmine.Async, v0.1.0
-// Copyright (c)2012 Muted Solutions, LLC. All Rights Reserved.
+// Copyright (c)2013 Muted Solutions, LLC. All Rights Reserved.
 // Distributed under MIT license
 // http://github.com/derickbailey/jasmine.async
-this.AsyncSpec=function(a){function b(a){return function(){var b=!1,c=function(){b=!0};runs(function(){a(c)}),waitsFor(function(){return b})}}function c(a){this.spec=a}return c.prototype.beforeEach=function(a){this.spec.beforeEach(b(a))},c.prototype.afterEach=function(a){this.spec.afterEach(b(a))},c.prototype.it=function(c,d){a.it(c,b(d))},c}(this);
+this.AsyncSpec=function(e){function t(e){return function(){var t=!1,n=function(){t=!0};runs(function(){try{e(n)}catch(t){throw n(),t}}),waitsFor(function(){return t})}}function n(e){this.spec=e}return n.prototype.beforeEach=function(e){this.spec.beforeEach(t(e))},n.prototype.afterEach=function(e){this.spec.afterEach(t(e))},n.prototype.it=function(n,r){e.it(n,t(r))},n}(this);

--- a/lib/jasmine.async.min.js
+++ b/lib/jasmine.async.min.js
@@ -2,4 +2,4 @@
 // Copyright (c)2013 Muted Solutions, LLC. All Rights Reserved.
 // Distributed under MIT license
 // http://github.com/derickbailey/jasmine.async
-this.AsyncSpec=function(e){function t(e){return function(){var t=!1,n=function(){t=!0};runs(function(){try{e(n)}catch(t){throw n(),t}}),waitsFor(function(){return t})}}function n(e){this.spec=e}return n.prototype.beforeEach=function(e){this.spec.beforeEach(t(e))},n.prototype.afterEach=function(e){this.spec.afterEach(t(e))},n.prototype.it=function(n,r){e.it(n,t(r))},n}(this);
+this.AsyncSpec=function(e){function t(e){return function(){var t=!1,n=function(){t=!0};runs(function(){try{e.call(this,n)}catch(t){throw n(),t}}),waitsFor(function(){return t})}}function n(e){this.spec=e}return n.prototype.beforeEach=function(e){this.spec.beforeEach(t(e))},n.prototype.afterEach=function(e){this.spec.afterEach(t(e))},n.prototype.it=function(n,r){e.it(n,t(r))},n}(this);

--- a/src/jasmine.async.js
+++ b/src/jasmine.async.js
@@ -10,7 +10,7 @@ this.AsyncSpec = (function(global){
 
       runs(function(){
         try{
-          block(complete);
+          block.call(this,complete);
         } catch ( error ){
           complete();
           throw error;

--- a/src/jasmine.async.js
+++ b/src/jasmine.async.js
@@ -9,7 +9,12 @@ this.AsyncSpec = (function(global){
       var complete = function(){ done = true; };
 
       runs(function(){
-        block(complete);
+        try{
+          block(complete);
+        } catch ( error ){
+          complete();
+          throw error;
+        }
       });
 
       waitsFor(function(){


### PR DESCRIPTION
In default Jasmine, when an error is thrown within a it() the tests will continue forward. 
If an error occurs within the block function provided, then the complete function is never invoked and thus the tests will not move forward until the timeout is triggered (default: 2000). Let me know if you guys need a sample. This solved our issues with several hundred tests taking "forever" on failures.
