### PR TITLE
Adding context to AsyncSpec

### DIFF
--- a/lib/jasmine.async.js
+++ b/lib/jasmine.async.js
@@ -1,5 +1,5 @@
 // Jasmine.Async, v0.1.0
-// Copyright (c)2012 Muted Solutions, LLC. All Rights Reserved.
+// Copyright (c)2013 Muted Solutions, LLC. All Rights Reserved.
 // Distributed under MIT license
 // http://github.com/derickbailey/jasmine.async
 this.AsyncSpec = (function(global){
@@ -7,13 +7,13 @@ this.AsyncSpec = (function(global){
   // Private Methods
   // ---------------
   
-  function runAsync(block){
+  function runAsync(block,ctx){
     return function(){
       var done = false;
       var complete = function(){ done = true; };
 
       runs(function(){
-        block(complete);
+        block.call(ctx,complete);
       });
 
       waitsFor(function(){
@@ -33,18 +33,19 @@ this.AsyncSpec = (function(global){
   // ----------
 
   AsyncSpec.prototype.beforeEach = function(block){
-    this.spec.beforeEach(runAsync(block));
+    this.spec.beforeEach(runAsync(block,this.spec));
   };
 
   AsyncSpec.prototype.afterEach = function(block){
-    this.spec.afterEach(runAsync(block));
+    this.spec.afterEach(runAsync(block,this.spec));
   };
 
   AsyncSpec.prototype.it = function(description, block){
     // For some reason, `it` is not attached to the current
     // test suite, so it has to be called from the global
     // context.
-    global.it(description, runAsync(block));
+
+    global.it(description, runAsync(block,this.spec));
   };
 
   return AsyncSpec;

--- a/lib/jasmine.async.min.js
+++ b/lib/jasmine.async.min.js
@@ -1,5 +1,5 @@
 // Jasmine.Async, v0.1.0
-// Copyright (c)2012 Muted Solutions, LLC. All Rights Reserved.
+// Copyright (c)2013 Muted Solutions, LLC. All Rights Reserved.
 // Distributed under MIT license
 // http://github.com/derickbailey/jasmine.async
-this.AsyncSpec=function(a){function b(a){return function(){var b=!1,c=function(){b=!0};runs(function(){a(c)}),waitsFor(function(){return b})}}function c(a){this.spec=a}return c.prototype.beforeEach=function(a){this.spec.beforeEach(b(a))},c.prototype.afterEach=function(a){this.spec.afterEach(b(a))},c.prototype.it=function(c,d){a.it(c,b(d))},c}(this);
+this.AsyncSpec=function(e){function t(e,t){return function(){var n=!1,r=function(){n=!0};runs(function(){e.call(t,r)}),waitsFor(function(){return n})}}function n(e){this.spec=e}return n.prototype.beforeEach=function(e){this.spec.beforeEach(t(e,this.spec))},n.prototype.afterEach=function(e){this.spec.afterEach(t(e,this.spec))},n.prototype.it=function(n,r){e.it(n,t(r,this.spec))},n}(this);

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "github": "https://github.com/derickbailey/jasmine.async",
 
   "devDependencies": {
-    "grunt": "*",
-    "grunt-rigger": "*"
+    "grunt": "0.3.17",
+    "grunt-rigger": "0.3.0"
   },
 
   "volo": {

--- a/src/jasmine.async.js
+++ b/src/jasmine.async.js
@@ -3,13 +3,13 @@ this.AsyncSpec = (function(global){
   // Private Methods
   // ---------------
   
-  function runAsync(block){
+  function runAsync(block,ctx){
     return function(){
       var done = false;
       var complete = function(){ done = true; };
 
       runs(function(){
-        block(complete);
+        block.call(ctx,complete);
       });
 
       waitsFor(function(){
@@ -29,18 +29,19 @@ this.AsyncSpec = (function(global){
   // ----------
 
   AsyncSpec.prototype.beforeEach = function(block){
-    this.spec.beforeEach(runAsync(block));
+    this.spec.beforeEach(runAsync(block,this.spec));
   };
 
   AsyncSpec.prototype.afterEach = function(block){
-    this.spec.afterEach(runAsync(block));
+    this.spec.afterEach(runAsync(block,this.spec));
   };
 
   AsyncSpec.prototype.it = function(description, block){
     // For some reason, `it` is not attached to the current
     // test suite, so it has to be called from the global
     // context.
-    global.it(description, runAsync(block));
+
+    global.it(description, runAsync(block,this.spec));
   };
 
   return AsyncSpec;


### PR DESCRIPTION
Allows you to do the following 

``` javascript
var async = new AsyncSpec(this);
async.beforeEach(function (done) {
  doSomePromise().then(function(foo){
    this.foo = foo; 
    done();
    });
  });
async.it('should have access to foo', function () {
  expect(this.foo).toBe('bar');
});

```
