### PR TITLE
Added jasmine.async.d.ts TypeScript definition file

### DIFF
--- a/lib/jasmine.async.d.ts
+++ b/lib/jasmine.async.d.ts
@@ -1,0 +1,13 @@
+
+// expose the AsyncSpec object
+declare var AsyncSpec: asyncjasmine.AsyncSpec;
+
+declare module asyncjasmine {
+
+    interface AsyncSpec {
+        new (spec: any);
+        beforeEach(block: (done: Function) => void): void;
+        afterEach(block: (done: Function) => void): void;
+        it(description: string, block: (done: Function) => void): void;
+    }
+}


### PR DESCRIPTION
This definition file allows the use of this with TypeScript.

For example:  

``` typescript
var async: asyncjasmine.AsyncSpec = new AsyncSpec(this);

async.beforeEach((done) => {
    //do stuff
    done();
});

async.it('is awesome', (done) => {
    setTimeout(() => {
        expect(true).toBe(true);
        done();
    }, 500);        
});

async.afterEach((done) => {
    //do stuff
    done();
});

```
