### PR TITLE
Preserve execution context

### DIFF
--- a/src/jasmine.async.js
+++ b/src/jasmine.async.js
@@ -9,7 +9,7 @@ this.AsyncSpec = (function(global){
       var complete = function(){ done = true; };
 
       runs(function(){
-        block(complete);
+        block.call(this, complete);
       });
 
       waitsFor(function(){


### PR DESCRIPTION
This change preserves the execution context in functions passed to async.beforeEach etc. so that the following code works:

``` javascript
describe("something", function () {
  var async = new Async(this);

  async.beforeEach(function (done) {
    var self = this;
    doSomethingAsync(function (asyncResult) {
      self.result = asyncResult;
      done();
    });
  });

  it("is ready", function () {
    expect(this.result).toBeDefined();
  });
});
```
