### PR TITLE
Xit proxy

### DIFF
--- a/src/jasmine.async.js
+++ b/src/jasmine.async.js
@@ -43,5 +43,7 @@ this.AsyncSpec = (function(global){
     global.it(description, runAsync(block));
   };
 
+  AsyncSpec.prototype.it = xit;
+
   return AsyncSpec;
 })(this);

--- a/src/jasmine.async.js
+++ b/src/jasmine.async.js
@@ -43,7 +43,7 @@ this.AsyncSpec = (function(global){
     global.it(description, runAsync(block));
   };
 
-  AsyncSpec.prototype.it = xit;
+  AsyncSpec.prototype.xit = xit;
 
   return AsyncSpec;
 })(this);


### PR DESCRIPTION
Proxied the xit function to make it easier to skip async specs.
