### PR TITLE
Minor change to allow using `this` for jasmine suite

### DIFF
--- a/src/jasmine.async.js
+++ b/src/jasmine.async.js
@@ -7,9 +7,10 @@ this.AsyncSpec = (function(global){
     return function(){
       var done = false;
       var complete = function(){ done = true; };
+      var suite = this;
 
       runs(function(){
-        block(complete);
+        block.call(suite, complete);
       });
 
       waitsFor(function(){


### PR DESCRIPTION
Especially when writing coffeescript tests it is common to use `this` for variables in scope 

A very minor change to allow this style

```
describe "a feature", ->
    async.beforeEach -> 
        @mockFoo = jasmine.createSpy()
        @sut = blah(mockFoo)

    it "calls foo", -> (expect @mockFoo).toHaveBeenCalled()
```
